### PR TITLE
Add config for the prompt to use

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -7,8 +7,13 @@
   "action": {},
   "permissions": [
     "scripting",
-    "activeTab"
+    "activeTab",
+    "storage"
   ],
+  "options_ui": {
+    "page": "options.html",
+    "open_in_tab": false
+  },
   "icons": {
     "16": "logo.png",
     "32": "logo.png",

--- a/public/options.html
+++ b/public/options.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html>
+  <head>
+    <title>Summarize Options</title>
+  </head>
+  <body>
+    <h1>Summarize Options</h1>
+    <p>
+      <label for="prompt">Prompt to use:</label>
+      <input type="text" id="prompt" size="40" value="" />
+    </p>
+    <button id="saveButton">Save</button>
+    <button id="resetButton">Reset</button>
+    <div id="status" style="display:inline-block"></div>
+    <script src="options.js"></script>
+  </body>
+</html>

--- a/public/options.js
+++ b/public/options.js
@@ -1,0 +1,40 @@
+const defaultPrompt = "Give me the summary of:";
+
+chrome.storage.sync.get("prompt", function (items) {
+    if (items.prompt) {
+        document.getElementById('prompt').value = items.prompt;
+    } else {
+        document.getElementById('prompt').value = defaultPrompt;
+    }
+});
+
+chrome.storage.sync.get({
+    prompt: defaultPrompt,
+}, function (items) {
+    document.getElementById('prompt').value = items.prompt;
+});
+
+function show_save_status() {
+    var status = document.getElementById('status');
+    status.textContent = 'Options saved.';
+    setTimeout(function () {
+        status.textContent = '';
+    }, 750);
+}
+
+function save_options() {
+    var prompt = document.getElementById('prompt').value;
+    chrome.storage.sync.set({
+        prompt: prompt,
+    }, show_save_status);
+}
+function restore_options() {
+    chrome.storage.sync.set({
+        prompt: defaultPrompt,
+    }, function () {
+        document.getElementById('prompt').value = defaultPrompt;
+        show_save_status();
+    });
+}
+document.getElementById('saveButton').addEventListener('click', save_options);
+document.getElementById('resetButton').addEventListener('click', restore_options);

--- a/src/background/index.js
+++ b/src/background/index.js
@@ -4,6 +4,11 @@ import { fetchSSE } from "./fetch-sse.js";
 
 const KEY_ACCESS_TOKEN = "accessToken";
 
+let prompt;
+chrome.storage.sync.get("prompt", function(items) {
+  prompt = items.prompt;
+});
+
 const cache = new ExpiryMap(10 * 1000);
 
 async function getAccessToken() {
@@ -85,7 +90,7 @@ chrome.runtime.onConnect.addListener((port) => {
   port.onMessage.addListener(async (request, sender, sendResponse) => {
     console.debug("received msg ", request.content);
     try {
-      const gptQuestion = `Rewrite this for brevity, in outline form:\n\n${request.content}`;
+      const gptQuestion = prompt + `\n\n${request.content}`;
       await getSummary(gptQuestion, (answer) => {
         port.postMessage({ answer });
       });

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -43,6 +43,8 @@ module.exports = {
         { from: 'public/res/logo.png', to: 'logo.png' },
         { from: 'public/res/logo-128.png', to: 'logo-128.png' },
         { from: 'public/styles.css', to: 'styles.css' },
+        { from: 'public/options.html', to: 'options.html' },
+        { from: 'public/options.js', to: 'options.js' },
       ],
     }),
     new CleanWebpackPlugin(),


### PR DESCRIPTION
Allows users to specify custom prompts, eg.: "Rewrite this for brevity,
in outline form:" or "Rewrite as a pirate": etc. 

<img width="694" alt="image" src="https://user-images.githubusercontent.com/4030927/205875803-0c7f6702-915b-4479-89e8-c24beee994ff.png">
