### PR TITLE
Use selection content if applicable

### DIFF
--- a/src/content/index.js
+++ b/src/content/index.js
@@ -199,7 +199,14 @@ async function run() {
   const innerContainer = container.querySelector(".summarize__content-inner-container");
   innerContainer.innerHTML = '<p class="loading">Waiting for ChatGPT response...</p>';
 
-  const content = getContentOfArticle();
+  let content;
+  let selection = window.getSelection();
+
+  if (selection.isCollapsed) {
+    content = getContentOfArticle();
+  } else {
+    content = selection.toString();
+  }
 
   const port = chrome.runtime.connect();
   port.onMessage.addListener(function (msg) {


### PR DESCRIPTION
If the user has a selection on the page, send the selection with the prompt. This is useful in two scenarios:
- The user wants to narrow down what should be summarized
- Workaround for when the article body is not correctly parsed

wanna have this functionality @clmnin ?