### PR TITLE
Add validation whether items is undefined at firefox

### DIFF
--- a/firefox/public/options.js
+++ b/firefox/public/options.js
@@ -3,7 +3,7 @@ const defaultPrompt =
 const defaultAPIKey = "";
 
 browser.storage.sync.get("prompt", function (items) {
-  if (items.prompt) {
+  if (items && items.prompt) {
     document.getElementById("prompt").value = items.prompt;
   } else {
     document.getElementById("prompt").value = defaultPrompt;
@@ -11,7 +11,7 @@ browser.storage.sync.get("prompt", function (items) {
 });
 
 browser.storage.sync.get("apiKey", function (items) {
-  if (items.apiKey) {
+  if (items && items.apiKey) {
     document.getElementById("apiKey").value = items.apiKey;
   } else {
     document.getElementById("apiKey").value = defaultAPIKey;
@@ -23,7 +23,9 @@ browser.storage.sync.get(
     prompt: defaultPrompt,
   },
   function (items) {
-    document.getElementById("prompt").value = items.prompt;
+    if (items) {
+      document.getElementById("prompt").value = items.prompt;
+    }
   }
 );
 
@@ -32,7 +34,9 @@ browser.storage.sync.get(
     apiKey: defaultAPIKey,
   },
   function (items) {
-    document.getElementById("apiKey").value = items.apiKey;
+    if (items) {
+      document.getElementById("apiKey").value = items.apiKey;
+    }
   }
 );
 


### PR DESCRIPTION
## Features

- Add validation whether items is undefined

## Screenshots

### As-is

- There is a Type error and "Default Prompt" is not seen

<img width="740" alt="Screenshot 2023-04-02 at 1 37 43" src="https://user-images.githubusercontent.com/38637046/229303459-1d624422-29a8-4efa-b5a9-c567713f7899.png">
<img width="675" alt="Screenshot 2023-04-02 at 1 39 10" src="https://user-images.githubusercontent.com/38637046/229303462-f31adc38-fbe8-4ae3-8d96-cfe330e48c41.png">

### To-be

- Fix all

<img width="685" alt="Screenshot 2023-04-02 at 1 35 09" src="https://user-images.githubusercontent.com/38637046/229303500-8982306b-9260-4474-85aa-36bd65f448b2.png">


## Changes

- fix: Edit firefox/public/options.js
  - Add validation whether items is undefined